### PR TITLE
Add mkdir /tts to avoid errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY server.py /root/server.py
 COPY shakkelha /root/shakkelha
 COPY models /root/models
 COPY constants /root/constants
+RUN mkdir /tts
 
 #CMD cd /root ; gunicorn -w 10 -b 0.0.0.0:8080 server:app
 CMD cd /root ; python3 server.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This will take about 20 mins
 
 # Accessing the server
 
-* In a browser: http://localhost:8080/shakkala/synth/<text_to_synthesise>
-* In a browser: http://localhost:8080/mishkal/synth/<text_to_synthesise>
+* In a browser: http://localhost:8080/shakkala/synth/file/<text_to_synthesise>
+* In a browser: http://localhost:8080/mishkal/synth/file/<text_to_synthesise>
 * NOTE if you are running docker on Windows (or with a docker machine in general) get the ip of the machine and use it instead of localhost above
 


### PR DESCRIPTION
1- Avoid errors like `[Errno 2] No such file or directory: '/tts/stage1_29208'[]` by adding `mkdir /tts` to Dockerfile
2- Fix urls in README.md (Was missing `/file/` in the endpoint)..